### PR TITLE
Allow overriding scheduler's `max_threads` setting

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -55,6 +55,7 @@ airflow::catchup: false
 airflow::dag_dir_list_interval: 300
 airflow::job_heartbeat_sec: 5
 airflow::scheduler_heartbeat_sec: 5
+airflow::scheduler_max_threads: 2
 airflow::auth_details: {}
 airflow::statsd_settings: {}
 airflow::mesos_settings: {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -228,7 +228,7 @@ class airflow (
   $dag_dir_list_interval,
   $job_heartbeat_sec,
   $scheduler_heartbeat_sec,
-
+  $scheduler_max_threads,
   $statsd_settings,
   $auth_details,
   $mesos_settings,
@@ -265,6 +265,7 @@ class airflow (
   validate_integer($dag_dir_list_interval)
   validate_integer($job_heartbeat_sec)
   validate_integer($scheduler_heartbeat_sec)
+  validate_integer($scheduler_max_threads)
   validate_integer($web_server_port)
   validate_integer($worker_concurrency)
   validate_integer($worker_log_server_port)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -73,6 +73,7 @@ class airflow::params {
   $dag_dir_list_interval       = 300
   $job_heartbeat_sec           = 5
   $scheduler_heartbeat_sec     = 5
+  $scheduler_max_threads       = 2
 
   $auth_details                = {}
   $statsd_settings             = {}

--- a/spec/fixtures/hieradata/test.yaml
+++ b/spec/fixtures/hieradata/test.yaml
@@ -51,6 +51,7 @@ airflow::default_queue: 'default'
 airflow::catchup: false
 airflow::job_heartbeat_sec: 5
 airflow::scheduler_heartbeat_sec: 5
+airflow::scheduler_max_threads: 4
 airflow::ldap_settings: {}
 airflow::statsd_settings: {}
 airflow::mesos_settings: {}

--- a/templates/airflow.cfg.erb
+++ b/templates/airflow.cfg.erb
@@ -186,6 +186,9 @@ job_heartbeat_sec = <%= @job_heartbeat_sec %>
 # how often the scheduler should run (in seconds).
 scheduler_heartbeat_sec = <%= @scheduler_heartbeat_sec %>
 
+# Threads count used by scheduler, default: 2
+max_threads = <%= @scheduler_max_threads %>
+
 # Turn off scheduler catchup by setting this to False.
 # Default behavior is unchanged and
 # Command Line Backfills still work, but the scheduler


### PR DESCRIPTION
Tests are not passing for me at all, on master too. I set to a different number of test.yml on purpose, so that if there's an actual test that tests result config it will check that it was overridden. But seems that there's no such test anyway.